### PR TITLE
Display status messages depending on how good or bad is the connection

### DIFF
--- a/MMM-network-signal.css
+++ b/MMM-network-signal.css
@@ -5,9 +5,10 @@
     border-top-color: #aaa;
     border-radius: 0.5em;
     height: 1em;
-    left: 50%;
+    left: 90%;
     position: relative;
     top: 50%;
+	margin-top: 30px;
     transition: border-top-color 0.3s linear;
     width: 1em;
     -webkit-transform: translate(-25%);

--- a/MMM-network-signal.js
+++ b/MMM-network-signal.js
@@ -14,12 +14,19 @@ Module.register("MMM-network-signal", {
         animationSpeed: 1000 * 0.25, // fade effect
         initialLoadDelay: 1000 * 3, // first check delay
         server: "8.8.8.8", // Server to check network connection. Default 8.8.8.8 is a Google DNS server
+		showMessage: true,
         thresholds: {
             strong: 50,
             medium: 150,
             weak: 500,
         },
     },
+    getTranslations: function() {
+		return {
+			en: "translations/en.json",
+      		es: "translations/es.json",
+		};
+	},
 
     // Custom CSS for wifi logo
     getStyles: function() {
@@ -44,26 +51,47 @@ Module.register("MMM-network-signal", {
         wrapper.className = "small";
 
         const signalClasses = this.getSignalClasses();
-
         const wifiSign = document.createElement("div");
+        if (this.config.showMessage)
+        {
+            wrapper.style = "display: flex; flex-direction: row"
+            var connStatus = document.createElement("p");
+            connStatus.style = "text-align: left";
+        }
 
         // Changing icon
         switch (true) {
             // Fast ping, strong signal
             case this.ping < this.config.thresholds.strong:
                 wifiSign.className = signalClasses.strong;
+                if (this.config.showMessage)
+                {
+                    connStatus.innerHTML = this.translate("excellent")
+                }
                 break;
             // Medium ping, medium signal
             case this.ping < this.config.thresholds.medium:
                 wifiSign.className = signalClasses.medium;
+                if (this.config.showMessage)
+                {
+                    connStatus.innerHTML = this.translate("good")
+                }
                 break;
             // Slow ping, weak signal
             case this.ping < this.config.thresholds.weak:
                 wifiSign.className = signalClasses.weak;
+                if (this.config.showMessage)
+                {
+                    connStatus.innerHTML = this.translate("normal")
+                }
                 break;
             // Ultraslow ping, better if "no signal"
             case this.ping > this.config.thresholds.weak:
                 wifiSign.className = signalClasses.none;
+                if (this.config.showMessage)
+                {
+                    connStatus.innerHTML = this.translate("bad")
+                }
                 break;
             // No actual ping, maybe just searching for signal
             default:
@@ -72,6 +100,10 @@ Module.register("MMM-network-signal", {
         }
 
         wrapper.appendChild(wifiSign);
+        if (this.config.showMessage)
+        {
+            wrapper.appendChild(connStatus);
+        }
         return wrapper;
     },
 

--- a/README.md
+++ b/README.md
@@ -34,3 +34,4 @@ Display a solid wifi logo as network signal for MagicMirror<sup>2</sup>
 | `initialLoadDelay` | `3000`                                   | Delay in ms for first ping              |
 | `server`           | `8.8.8.8`                                | Pingable server IP address              |
 | `thresholds`       | `{ strong: 50, medium: 150, weak: 500 }` | Tresholds for icons (ping answer in ms) |
+| `showMessage`      | `true`                                   | Shows status messages depending on how good or bad is the connection |

--- a/translations/en.json
+++ b/translations/en.json
@@ -1,0 +1,6 @@
+{
+  "excellent": "Excellent",
+  "good": "Good",
+  "normal": "Acceptable",
+  "bad": "Bad"
+}

--- a/translations/es.json
+++ b/translations/es.json
@@ -1,0 +1,6 @@
+{
+  "excellent": "Excelente",
+  "good": "Buena",
+  "normal": "Aceptable",
+  "bad": "Mediocre"
+}


### PR DESCRIPTION
Aside from the icon, which has been moved to the left inside the wrapper, now users can configure whether they want to see status messages like "Excellent", "Good", "Acceptable" or "Bad" in their mirrors. Those messages are translated to Spanish and English.