### PR TITLE
add extra configs for row direction and icon scale

### DIFF
--- a/MMM-network-signal.js
+++ b/MMM-network-signal.js
@@ -20,12 +20,14 @@ Module.register("MMM-network-signal", {
             medium: 150,
             weak: 500,
         },
+        flexDirection: 'row', // set to 'row' to display the row in left-to-right mode, 'row-reverse' to display the row in right-to-left mode
+        scale: 0.45 // scale for the icon, must be greater than 0
     },
     getTranslations: function() {
 		return {
 			de: "translations/de.json",
 			en: "translations/en.json",
-      			es: "translations/es.json",
+			es: "translations/es.json",
 			fr: "translations/fr.json"
 		};
 	},
@@ -44,9 +46,9 @@ Module.register("MMM-network-signal", {
 
     getDom: function() {
         const content = document.createElement("div");
-        content.style = "display: flex;flex-direction: row;justify-content: space-between; align-items: center";
+        content.style = `display: flex;flex-direction: ${this.config.flexDirection};justify-content: space-between; align-items: center`;
         const wifiSign = document.createElement("img");
-        wifiSign.style = "transform:scale(0.45)";
+        wifiSign.style = `transform:scale(${this.config.scale})`;
         if (this.config.showMessage)
         {
             var connStatus = document.createElement("p");

--- a/README.md
+++ b/README.md
@@ -36,3 +36,5 @@ Display a solid wifi logo as network signal for MagicMirror<sup>2</sup>
 | `server`           | `8.8.8.8`                                | Pingable server IP address              |
 | `thresholds`       | `{ strong: 50, medium: 150, weak: 500 }` | Tresholds for icons (ping answer in ms) |
 | `showMessage`      | `true`                                   | Shows status messages depending on how good or bad is the connection |
+| `flexDirection`    | `row`                                    | Sets the direction the module is displayed; `row` displays the row in left-to-right mode (default), `row-reverse` displays the row in right-to-left mode. |
+| `scale`            | `0.45`                                   | How much to scale the ping icon. Must be greater than 0. |


### PR DESCRIPTION
`flexDirection` can be used to display the row in left-to-right mode ('row', default) or right-to-left mode ('row-reverse'); `scale` can be used to change the size of the rendered icon